### PR TITLE
Revert "fix taranis mappings"

### DIFF
--- a/src/rosflight_joy/rosflight_joystick_base.py
+++ b/src/rosflight_joy/rosflight_joystick_base.py
@@ -38,10 +38,10 @@ class rosflight_joystick_base():
 
         if 'Taranis' in self.joy.get_name():
             print "found Taranis"
-            self.mapping['x'] = 1
-            self.mapping['y'] = 2
+            self.mapping['x'] = 0
+            self.mapping['y'] = 1
             self.mapping['z'] = 3
-            self.mapping['F'] = 0
+            self.mapping['F'] = 2
             self.mapping['xsign'] = 1
             self.mapping['ysign'] = 1
             self.mapping['zsign'] = 1


### PR DESCRIPTION
This reverts commit d3799aed8c760a9a5f34cf0418f3d9b25b0dbd7a.

The problem with this change is that the Taranis now looks
to the sim than it does on hardware. With this change a Taranis
in TAER mode will look like AETR mode to the sim, but will still
look like TAER mode to the hardware. So the mapping between sim
hardware is broken. The correct solution is to configure the
Taranis to be in AETR mode.