### PR TITLE
Add rc_keyboard: mimic transmitter with keyboard input

### DIFF
--- a/src/rosflight_joy/angle_command_joy
+++ b/src/rosflight_joy/angle_command_joy
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import rospy
 from rosflight_msgs.msg import Command

--- a/src/rosflight_joy/rc_joy
+++ b/src/rosflight_joy/rc_joy
@@ -1,5 +1,4 @@
-#!/usr/bin/python
-
+#!/usr/bin/env python3
 import rospy
 import time
 from rosflight_msgs.msg import RCRaw
@@ -16,7 +15,6 @@ class rosflight_joystic_RC(rosflight_joystick_base):
             if self.update():
                 msg = RCRaw()
                 msg.header.stamp = rospy.Time.now()
-
                 msg.values[0] = self.get_value('x')
                 msg.values[1] = self.get_value('y')
                 msg.values[2] = self.get_value('F')
@@ -25,13 +23,12 @@ class rosflight_joystic_RC(rosflight_joystick_base):
                 msg.values[5] = self.get_value('aux2')
                 msg.values[6] = self.get_value('aux3')
                 msg.values[7] = self.get_value('aux4')
-
                 rc_pub.publish(msg)
 
             time.sleep(0.02)
 
     def get_value(self, key):
-        return self.values[key] * 500 + 1500
+        return int(self.values[key] * 500 + 1500)
 
 if __name__ == "__main__":
     joy_object = rosflight_joystic_RC()

--- a/src/rosflight_joy/rc_keyboard
+++ b/src/rosflight_joy/rc_keyboard
@@ -18,8 +18,9 @@ class rosflight_keyboard_RC(rosflight_keyboard_base):
         rospy.sleep(3)
 
         while not rospy.is_shutdown():
-            if not self.armed and not self.init:
+            if not self.init:
                 if self.armed:
+                    rospy.loginfo("[rc_keyboard] auto-arming successful")
                     self.init = True
                     continue
 

--- a/src/rosflight_joy/rc_keyboard
+++ b/src/rosflight_joy/rc_keyboard
@@ -15,11 +15,11 @@ class rosflight_keyboard_RC(rosflight_keyboard_base):
             if self.update():
                 msg = RCRaw()
                 msg.header.stamp = rospy.Time.now()
-                msg.values[0] = self.get_value('x') # R - L/R
-                msg.values[1] = self.get_value('y') # R - U/D
-                msg.values[2] = self.get_value('F') # L - U/D
-                msg.values[3] = self.get_value('z') # L - L/R
-                msg.values[4] = self.get_value('aux1') # SF
+                msg.values[0] = self.get_value('x') 
+                msg.values[1] = self.get_value('y') 
+                msg.values[2] = self.get_value('F') 
+                msg.values[3] = self.get_value('z') 
+                msg.values[4] = self.get_value('aux1')
                 msg.values[5] = self.get_value('aux2')
                 msg.values[6] = self.get_value('aux3')
                 msg.values[7] = self.get_value('aux4')
@@ -31,4 +31,4 @@ class rosflight_keyboard_RC(rosflight_keyboard_base):
         return int(self.values[key] * 500 + 1500)
 
 if __name__ == "__main__":
-    joy_object = rosflight_keyboard_RC()
+    input_object = rosflight_keyboard_RC()

--- a/src/rosflight_joy/rc_keyboard
+++ b/src/rosflight_joy/rc_keyboard
@@ -18,6 +18,7 @@ class rosflight_keyboard_RC(rosflight_keyboard_base):
         rospy.sleep(3)
 
         while not rospy.is_shutdown():
+            self.update()
             if not self.init:
                 if self.armed:
                     rospy.loginfo("[rc_keyboard] auto-arming successful")
@@ -30,13 +31,13 @@ class rosflight_keyboard_RC(rosflight_keyboard_base):
                 msg.values[1] = 1500
                 msg.values[2] = 1000
                 msg.values[3] = 2000
-                msg.values[4] = 1000
+                msg.values[4] = 2000
                 msg.values[5] = 1000
                 msg.values[6] = 1000
                 msg.values[7] = 1000
                 rc_pub.publish(msg)
 
-            elif self.update():
+            else:
                 msg = RCRaw()
                 msg.header.stamp = rospy.Time.now()
                 msg.values[0] = self.get_value('x') 

--- a/src/rosflight_joy/rc_keyboard
+++ b/src/rosflight_joy/rc_keyboard
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import rospy
 import time
-from rosflight_msgs.msg import RCRaw
+from rosflight_msgs.msg import RCRaw, Status
 from rosflight_keyboard_base import rosflight_keyboard_base
 
 class rosflight_keyboard_RC(rosflight_keyboard_base):
@@ -10,9 +10,32 @@ class rosflight_keyboard_RC(rosflight_keyboard_base):
 
         rospy.init_node('rc_keyboard')
         rc_pub = rospy.Publisher('RC', RCRaw, queue_size=10)
+        
+        rospy.Subscriber('status', Status, self.status_callback)
+        self.armed = False
+        self.init = False
+
+        rospy.sleep(3)
 
         while not rospy.is_shutdown():
-            if self.update():
+            if not self.armed and not self.init:
+                if self.armed:
+                    self.init = True
+                    continue
+
+                msg = RCRaw()
+                msg.header.stamp = rospy.Time.now()
+                msg.values[0] = 1500
+                msg.values[1] = 1500
+                msg.values[2] = 1000
+                msg.values[3] = 2000
+                msg.values[4] = 1000
+                msg.values[5] = 1000
+                msg.values[6] = 1000
+                msg.values[7] = 1000
+                rc_pub.publish(msg)
+
+            elif self.update():
                 msg = RCRaw()
                 msg.header.stamp = rospy.Time.now()
                 msg.values[0] = self.get_value('x') 
@@ -25,10 +48,13 @@ class rosflight_keyboard_RC(rosflight_keyboard_base):
                 msg.values[7] = self.get_value('aux4')
                 rc_pub.publish(msg)
 
-            time.sleep(0.02)
+            rospy.sleep(0.02)
 
     def get_value(self, key):
         return int(self.values[key] * 500 + 1500)
+
+    def status_callback(self, msg):
+        self.armed = msg.armed
 
 if __name__ == "__main__":
     input_object = rosflight_keyboard_RC()

--- a/src/rosflight_joy/rc_keyboard
+++ b/src/rosflight_joy/rc_keyboard
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+import rospy
+import time
+from rosflight_msgs.msg import RCRaw
+from rosflight_keyboard_base import rosflight_keyboard_base
+
+class rosflight_keyboard_RC(rosflight_keyboard_base):
+    def __init__(self, device = 0):
+        rosflight_keyboard_base.__init__(self, device)
+
+        rospy.init_node('rc_keyboard')
+        rc_pub = rospy.Publisher('RC', RCRaw, queue_size=10)
+
+        while not rospy.is_shutdown():
+            if self.update():
+                msg = RCRaw()
+                msg.header.stamp = rospy.Time.now()
+                msg.values[0] = self.get_value('x') # R - L/R
+                msg.values[1] = self.get_value('y') # R - U/D
+                msg.values[2] = self.get_value('F') # L - U/D
+                msg.values[3] = self.get_value('z') # L - L/R
+                msg.values[4] = self.get_value('aux1') # SF
+                msg.values[5] = self.get_value('aux2')
+                msg.values[6] = self.get_value('aux3')
+                msg.values[7] = self.get_value('aux4')
+                rc_pub.publish(msg)
+
+            time.sleep(0.02)
+
+    def get_value(self, key):
+        return int(self.values[key] * 500 + 1500)
+
+if __name__ == "__main__":
+    joy_object = rosflight_keyboard_RC()

--- a/src/rosflight_joy/rosflight_joystick_base.py
+++ b/src/rosflight_joy/rosflight_joystick_base.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # author: James Jackson
 
@@ -17,8 +17,8 @@ class rosflight_joystick_base():
         self.joy = pygame.joystick.Joystick(device)
         self.joy.init()
 
-        print "joystick: {} (axes: {}, buttons: {}, hats: {})".format(
-            self.joy.get_name(), self.joy.get_numaxes(), self.joy.get_numbuttons(), self.joy.get_numhats())
+        print("joystick: {} (axes: {}, buttons: {}, hats: {})".format(
+            self.joy.get_name(), self.joy.get_numaxes(), self.joy.get_numbuttons(), self.joy.get_numhats()))
 
         self.mapping = dict()
 
@@ -37,13 +37,13 @@ class rosflight_joystick_base():
         self.next_update_time = time.time()
 
         if 'Taranis' in self.joy.get_name():
-            print "found Taranis"
+            print("found Taranis")
             self.mapping['x'] = 1
             self.mapping['y'] = 2
             self.mapping['z'] = 3
             self.mapping['F'] = 0
             self.mapping['xsign'] = 1
-            self.mapping['ysign'] = 1
+            self.mapping['ysign'] = -1
             self.mapping['zsign'] = 1
             self.mapping['Fsign'] = 1
             self.mapping['aux1'] = {'type': 'axis', 'id': 4}
@@ -52,7 +52,7 @@ class rosflight_joystick_base():
             self.mapping['aux4'] = {'type': 'switch', 'id': 2}
 
         elif 'Xbox' in self.joy.get_name() or 'X-Box' in self.joy.get_name():
-            print "found xbox"
+            # print "found xbox"
             self.mapping['x'] = 3
             self.mapping['y'] = 4
             self.mapping['z'] = 0
@@ -68,7 +68,7 @@ class rosflight_joystick_base():
             self.look_for_button_press_events = True
 
         elif 'Extreme 3D' in self.joy.get_name():
-            print "found Logitech Extreme 3D"
+            # print "found Logitech Extreme 3D"
             self.mapping['x'] = 0
             self.mapping['y'] = 1
             self.mapping['z'] = 2
@@ -85,7 +85,7 @@ class rosflight_joystick_base():
             self.look_for_button_press_events = True
 
         else:
-            print "using realflight mapping"
+            print("using realflight mapping")
             self.mapping['x'] = 1
             self.mapping['y'] = 2
             self.mapping['z'] = 4

--- a/src/rosflight_joy/rosflight_joystick_base.py
+++ b/src/rosflight_joy/rosflight_joystick_base.py
@@ -44,7 +44,7 @@ class rosflight_joystick_base():
             self.mapping['z'] = 3
             self.mapping['F'] = 2
             self.mapping['xsign'] = 1
-            self.mapping['ysign'] = -1
+            self.mapping['ysign'] = 1
             self.mapping['zsign'] = 1
             self.mapping['Fsign'] = 1
             self.mapping['aux1'] = {'type': 'axis', 'id': 4}
@@ -53,7 +53,7 @@ class rosflight_joystick_base():
             self.mapping['aux4'] = {'type': 'switch', 'id': 2}
 
         elif 'Xbox' in self.joy.get_name() or 'X-Box' in self.joy.get_name():
-            # print "found xbox"
+            print("found xbox")
             self.mapping['x'] = 3
             self.mapping['y'] = 4
             self.mapping['z'] = 0
@@ -69,7 +69,7 @@ class rosflight_joystick_base():
             self.look_for_button_press_events = True
 
         elif 'Extreme 3D' in self.joy.get_name():
-            # print "found Logitech Extreme 3D"
+            print("found Logitech Extreme 3D")
             self.mapping['x'] = 0
             self.mapping['y'] = 1
             self.mapping['z'] = 2
@@ -125,7 +125,7 @@ class rosflight_joystick_base():
                                             self.button_keys):
                 if current != prev and current == 1:
                     self.values[key] = -1 * self.values[key]
-                    # print "button action: key:",key, "id:",self.mapping[key]['id'], "toggle-state:",self.values[key]
+                    # print("button action: key:",key, "id:",self.mapping[key]['id'], "toggle-state:",self.values[key])
 
             # Note that storing the values as a plain, key-less list between loops does only work if the
             # self.mapping dict is not modified at all. std-dict iterates in arbitrary order.

--- a/src/rosflight_joy/rosflight_keyboard_base.py
+++ b/src/rosflight_joy/rosflight_keyboard_base.py
@@ -44,7 +44,7 @@ class rosflight_keyboard_base():
         self.delta = 0.02
 
         self.next_update_time = time.time()
-        self.switch_wait_time = time.time()
+        self.switch_wait_until_time = time.time()
         self.switch_interval_time = 0.25
 
     def update(self):
@@ -57,9 +57,10 @@ class rosflight_keyboard_base():
                 if event.type == pygame.KEYDOWN and event.key in self.actions:
                     name = self.actions[event.key]['name']
                     sign = self.actions[event.key]['sign']
-                    if name == 'aux1' and time.time() > self.switch_wait_time:
+                    t = time.time()
+                    if name == 'aux1' and t > self.switch_wait_until_time:
                         self.values['aux1'] *= -1
-                        self.switch_wait_time = time.time() + self.switch_interval_time
+                        self.switch_wait_until_time = t + self.switch_interval_time
                     elif name != 'aux1':
                         self.shift_value(name, sign)
                     elif event.key == pygame.K_q:

--- a/src/rosflight_joy/rosflight_keyboard_base.py
+++ b/src/rosflight_joy/rosflight_keyboard_base.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+
+# author: James Jackson
+
+import os
+import time
+import pygame
+
+
+class rosflight_keyboard_base():
+    def __init__(self, device=0):
+        os.environ["SDL_VIDEODRIVER"] = "dummy"
+        pygame.display.init()
+        screen = pygame.display.set_mode((1, 1))
+        pygame.joystick.init()
+
+        self.joy = pygame.joystick.Joystick(device)
+        self.joy.init()
+
+        print("joystick: {} (axes: {}, buttons: {}, hats: {})".format(
+            self.joy.get_name(), self.joy.get_numaxes(), self.joy.get_numbuttons(), self.joy.get_numhats()))
+
+        self.mapping = dict()
+
+        self.look_for_button_press_events = False
+
+        self.values = dict()
+        self.values['x'] = 0
+        self.values['y'] = 0
+        self.values['F'] = 0
+        self.values['z'] = 0
+        self.values['aux1'] = -1
+        self.values['aux2'] = -1
+        self.values['aux3'] = -1
+        self.values['aux4'] = -1
+
+        self.next_update_time = time.time()
+
+        if 'Taranis' in self.joy.get_name():
+            print("found Taranis")
+            self.mapping['x'] = 1
+            self.mapping['y'] = 2
+            self.mapping['z'] = 3
+            self.mapping['F'] = 0
+            self.mapping['xsign'] = 1
+            self.mapping['ysign'] = -1
+            self.mapping['zsign'] = 1
+            self.mapping['Fsign'] = 1
+            self.mapping['aux1'] = {'type': 'axis', 'id': 4}
+            self.mapping['aux2'] = {'type': 'axis', 'id': 5}
+            self.mapping['aux3'] = {'type': 'axis', 'id': 6}
+            self.mapping['aux4'] = {'type': 'switch', 'id': 2}
+
+        elif 'Xbox' in self.joy.get_name() or 'X-Box' in self.joy.get_name():
+            # print "found xbox"
+            self.mapping['x'] = 3
+            self.mapping['y'] = 4
+            self.mapping['z'] = 0
+            self.mapping['F'] = 1
+            self.mapping['xsign'] = 1
+            self.mapping['ysign'] = 1
+            self.mapping['zsign'] = 1
+            self.mapping['Fsign'] = -1
+            self.mapping['aux1'] = {'type': 'button', 'id': 0}
+            self.mapping['aux2'] = {'type': 'button', 'id': 1}
+            self.mapping['aux3'] = {'type': 'button', 'id': 2}
+            self.mapping['aux4'] = {'type': 'button', 'id': 3}
+            self.look_for_button_press_events = True
+
+        elif 'Extreme 3D' in self.joy.get_name():
+            # print "found Logitech Extreme 3D"
+            self.mapping['x'] = 0
+            self.mapping['y'] = 1
+            self.mapping['z'] = 2
+            self.mapping['F'] = 3
+            self.mapping['xsign'] = 1
+            self.mapping['ysign'] = 1
+            self.mapping['zsign'] = 1
+            self.mapping['Fsign'] = -1
+            self.mapping['aux1'] = {'type': 'button', 'id': 0}
+            self.mapping['aux2'] = {'type': 'button', 'id': 1}
+            self.mapping['aux3'] = {'type': 'button', 'id': 2}
+            self.mapping['aux4'] = {'type': 'button', 'id': 3}
+            # the Extreme 3D has actually 12 buttons, but rc_joy forwards only 4 aux keys
+            self.look_for_button_press_events = True
+
+        else:
+            print("using realflight mapping")
+            self.mapping['x'] = 1
+            self.mapping['y'] = 2
+            self.mapping['z'] = 4
+            self.mapping['F'] = 0
+            self.mapping['xsign'] = 1
+            self.mapping['ysign'] = 1
+            self.mapping['zsign'] = 1
+            self.mapping['Fsign'] = 1
+            self.mapping['aux1'] = {'type': 'axis', 'id': 3}
+            self.mapping['aux2'] = {'type': 'switch', 'id': 0}
+            self.mapping['aux3'] = {'type': 'switch', 'id': 1}
+            self.mapping['aux4'] = {'type': 'switch', 'id': 2}
+
+        if self.look_for_button_press_events:
+            # get keys for all inputs typed as 'button'
+            self.button_keys = [key for key in self.mapping.iterkeys()
+                                if 'aux' in key and self.mapping[key]['type'] == 'button']
+            # initialize values for the buttons
+            self.prev_button_values = []
+            for key in self.button_keys:
+                button_value = self.joy.get_button(self.mapping[key]['id'])
+                self.prev_button_values.append(button_value)
+                self.mapping[key]['value'] = button_value
+
+    def update(self):
+        pygame.event.pump()
+
+        # Look for button press events in the case of a joystick controller
+        # (switch value on button press)
+        if self.look_for_button_press_events:
+            # get values for the buttons
+            current_button_values = [self.joy.get_button(
+                self.mapping[key]['id']) for key in self.button_keys]
+
+            for (current, prev, key) in zip(current_button_values,
+                                            self.prev_button_values,
+                                            self.button_keys):
+                if current != prev and current == 1:
+                    self.values[key] = -1 * self.values[key]
+                    # print "button action: key:",key, "id:",self.mapping[key]['id'], "toggle-state:",self.values[key]
+
+            # Note that storing the values as a plain, key-less list between loops does only work if the
+            # self.mapping dict is not modified at all. std-dict iterates in arbitrary order.
+            self.prev_button_values = current_button_values
+
+        # For 'switch' type aux keys, the published value is directly the current state of being pressed.
+        # Updated in below loop. Same for 'axis' type aux keys.
+
+        # 50 Hz update
+        if time.time() > self.next_update_time:
+            self.next_update_time += 0.02
+
+            self.values['x'] = self.joy.get_axis(
+                self.mapping['x']) * self.mapping['xsign']
+            self.values['y'] = self.joy.get_axis(
+                self.mapping['y']) * self.mapping['ysign']
+            self.values['F'] = self.joy.get_axis(
+                self.mapping['F']) * self.mapping['Fsign']
+            self.values['z'] = self.joy.get_axis(
+                self.mapping['z']) * self.mapping['zsign']
+
+            for key in ['aux1', 'aux2', 'aux3', 'aux4']:
+                if self.mapping[key]['type'] == 'axis':
+                    self.values[key] = self.joy.get_axis(
+                        self.mapping[key]['id'])
+                elif self.mapping[key]['type'] == 'switch':
+                    self.values[key] = 2.0 * \
+                        self.joy.get_button(self.mapping[key]['id']) - 1.0
+            return True
+        else:
+            return False
+
+    def get_value(self, key):
+        return self.values[key]

--- a/src/rosflight_joy/rosflight_keyboard_base.py
+++ b/src/rosflight_joy/rosflight_keyboard_base.py
@@ -9,16 +9,17 @@ import pygame
 
 class rosflight_keyboard_base():
     def __init__(self, device=0):
-        os.environ["SDL_VIDEODRIVER"] = "dummy"
+        os.environ["SDL_VIDEODRIVER"] = "x11"
         pygame.display.init()
-        screen = pygame.display.set_mode((100, 100))
+        screen = pygame.display.set_mode((1, 1))
+        pygame.key.set_repeat(1, 10)
 
         print("pygame with keyboard control")
 
         self.mapping = dict()
 
-        self.look_for_button_press_events = False
-        self.keypress = False
+        self.print_limits = False
+        self.limit_reached = False
 
         self.values = dict()
         self.values['x'] = 0
@@ -30,94 +31,83 @@ class rosflight_keyboard_base():
         self.values['aux3'] = -1
         self.values['aux4'] = -1
 
+        self.actions = dict()
+        self.actions[pygame.K_UP]    = {'name':    'y', 'sign': -1, 'state': 0}
+        self.actions[pygame.K_DOWN]  = {'name':    'y', 'sign':  1, 'state': 0}
+        self.actions[pygame.K_LEFT]  = {'name':    'x', 'sign': -1, 'state': 0}
+        self.actions[pygame.K_RIGHT] = {'name':    'x', 'sign':  1, 'state': 0}
+        self.actions[pygame.K_w]     = {'name':    'F', 'sign':  1, 'state': 0}
+        self.actions[pygame.K_s]     = {'name':    'F', 'sign': -1, 'state': 0}
+        self.actions[pygame.K_a]     = {'name':    'z', 'sign': -1, 'state': 0}
+        self.actions[pygame.K_d]     = {'name':    'z', 'sign':  1, 'state': 0}
+        self.actions[pygame.K_o]     = {'name': 'aux1', 'sign':  1, 'state': 0}
+        self.delta = 0.02
+
         self.next_update_time = time.time()
-
-        self.mapping['x'] = 1  # R - L/R
-        self.mapping['y'] = 2  # R - U/D
-        self.mapping['z'] = 3  # L - L/R
-        self.mapping['F'] = 0  # L - U/D
-        self.mapping['xsign'] = 1
-        self.mapping['ysign'] = -1
-        self.mapping['zsign'] = 1
-        self.mapping['Fsign'] = 1
-        self.mapping['aux1'] = {'type': 'axis', 'id': 4}
-        self.mapping['aux2'] = {'type': 'axis', 'id': 5}
-        self.mapping['aux3'] = {'type': 'axis', 'id': 6}
-        self.mapping['aux4'] = {'type': 'switch', 'id': 2}
-
-        self.keys_increase = [pygame.K_RIGHT, pygame.K_UP, pygame.K_d, pygame.K_w]
-
-        self.keys_decrease = [pygame.K_LEFT, pygame.K_DOWN, pygame.K_a, pygame.K_s, pygame.K_o]
-
-        if self.look_for_button_press_events:
-            # get keys for all inputs typed as 'button'
-            self.button_keys = [key for key in self.mapping.iterkeys()
-                                if 'aux' in key and self.mapping[key]['type'] == 'button']
-            # initialize values for the buttons
-            self.prev_button_values = []
-            for key in self.button_keys:
-                button_value = self.joy.get_button(self.mapping[key]['id'])
-                self.prev_button_values.append(button_value)
+        self.switch_wait_time = time.time()
+        self.switch_interval_time = 0.25
 
     def update(self):
         pygame.event.pump()
 
-        # Look for button press events in the case of a joystick controller
-        # (switch value on button press)
-        if self.look_for_button_press_events:
-            # get values for the buttons
-            current_button_values = [self.joy.get_button(
-                self.mapping[key]['id']) for key in self.button_keys]
-
-            for (current, prev, key) in zip(current_button_values,
-                                            self.prev_button_values,
-                                            self.button_keys):
-                if current != prev and current == 1:
-                    self.values[key] = -1 * self.values[key]
-                    # print "button action: key:",key, "id:",self.mapping[key]['id'], "toggle-state:",self.values[key]
-
-            # Note that storing the values as a plain, key-less list between loops does only work if the
-            # self.mapping dict is not modified at all. std-dict iterates in arbitrary order.
-            self.prev_button_values = current_button_values
-
-        # For 'switch' type aux keys, the published value is directly the current state of being pressed.
-        # Updated in below loop. Same for 'axis' type aux keys.
-
-        
-                # self.keypress = True
-
         # 50 Hz update
         if time.time() > self.next_update_time:
             self.next_update_time += 0.02
-
-
             for event in pygame.event.get():
-                if event.type == pygame.KEYDOWN:
-                    if event.key == pygame.K_DOWN:
-                        print("Pressing down!")
-                if event.type == pygame.KEYUP:
-                    print('\nkey up: {}, {}\n'.format(event.key, pygame.key.name(event.key)))
-
-            self.values['x'] = self.mapping['xsign']
-            self.values['y'] = self.mapping['ysign']
-            self.values['F'] = self.mapping['Fsign']
-            self.values['z'] = self.mapping['zsign']
-
-
-            for key in ['aux1', 'aux2', 'aux3', 'aux4']:
-                if self.mapping[key]['type'] == 'axis':
-                    self.values[key] = 10
-                    # self.values[key] = self.joy.get_axis(
-                        # self.mapping[key]['id'])
-                elif self.mapping[key]['type'] == 'switch':
-                    self.values[key] = 1
-                    # self.values[key] = 2.0 * \
-                    #     self.joy.get_button(self.mapping[key]['id']) - 1.0
-
-            self.keypress = False
+                if event.type == pygame.KEYDOWN and event.key in self.actions:
+                    name = self.actions[event.key]['name']
+                    sign = self.actions[event.key]['sign']
+                    if name == 'aux1' and time.time() > self.switch_wait_time:
+                        self.values['aux1'] *= -1
+                        self.switch_wait_time = time.time() + self.switch_interval_time
+                    elif name != 'aux1':
+                        self.shift_value(name, sign)
+                    elif event.key == pygame.K_q:
+                        exit(0)
+                    self.actions[event.key]['state'] = 1
+                elif event.type == pygame.KEYUP and event.key in self.actions:
+                    self.actions[event.key]['state'] = 0
+            self.slide_to_zero(self.actions)
             return True
         else:
             return False
 
     def get_value(self, key):
         return self.values[key]
+
+    def shift_value(self, name, sign):
+        ''' increment or decrement value of axis [name] in [sign] direction'''
+        self.values[name] += sign * self.delta
+        val = self.values[name]
+        if abs(val) >= 1.0:
+            val = 1.0 if val > 0 else -1.0
+            if not self.limit_reached and self.print_limits:
+                print('{} {} value reached'.format(name, 
+                                            'max' if val > 0 else 'min'))
+                self.limit_reached = True
+        else:
+            self.limit_reached = False
+
+        if abs(val) < 1e-6:
+            val = 0.
+        self.values[name] = val
+        
+    def slide_to_zero(self, actions):
+        ''' for x,y,z axes, push values closer to zero if not currently pressed 
+            (joystick behavior)
+        '''
+        for n in ['x', 'y', 'z']:
+            is_pressed = False
+            for key in actions:
+                if self.actions[key]['name'] == n and self.actions[key]['state']:
+                    is_pressed = True
+            if is_pressed:
+                continue
+                
+            val = self.values[n]
+            if abs(val) < 1e-6:
+                val = 0.
+            else:
+                val += self.delta if val < 0 else -self.delta
+            self.values[n] = val
+    

--- a/src/rosflight_joy/rosflight_keyboard_base.py
+++ b/src/rosflight_joy/rosflight_keyboard_base.py
@@ -11,18 +11,14 @@ class rosflight_keyboard_base():
     def __init__(self, device=0):
         os.environ["SDL_VIDEODRIVER"] = "dummy"
         pygame.display.init()
-        screen = pygame.display.set_mode((1, 1))
-        pygame.joystick.init()
+        screen = pygame.display.set_mode((100, 100))
 
-        self.joy = pygame.joystick.Joystick(device)
-        self.joy.init()
-
-        print("joystick: {} (axes: {}, buttons: {}, hats: {})".format(
-            self.joy.get_name(), self.joy.get_numaxes(), self.joy.get_numbuttons(), self.joy.get_numhats()))
+        print("pygame with keyboard control")
 
         self.mapping = dict()
 
         self.look_for_button_press_events = False
+        self.keypress = False
 
         self.values = dict()
         self.values['x'] = 0
@@ -36,68 +32,22 @@ class rosflight_keyboard_base():
 
         self.next_update_time = time.time()
 
-        if 'Taranis' in self.joy.get_name():
-            print("found Taranis")
-            self.mapping['x'] = 1
-            self.mapping['y'] = 2
-            self.mapping['z'] = 3
-            self.mapping['F'] = 0
-            self.mapping['xsign'] = 1
-            self.mapping['ysign'] = -1
-            self.mapping['zsign'] = 1
-            self.mapping['Fsign'] = 1
-            self.mapping['aux1'] = {'type': 'axis', 'id': 4}
-            self.mapping['aux2'] = {'type': 'axis', 'id': 5}
-            self.mapping['aux3'] = {'type': 'axis', 'id': 6}
-            self.mapping['aux4'] = {'type': 'switch', 'id': 2}
+        self.mapping['x'] = 1  # R - L/R
+        self.mapping['y'] = 2  # R - U/D
+        self.mapping['z'] = 3  # L - L/R
+        self.mapping['F'] = 0  # L - U/D
+        self.mapping['xsign'] = 1
+        self.mapping['ysign'] = -1
+        self.mapping['zsign'] = 1
+        self.mapping['Fsign'] = 1
+        self.mapping['aux1'] = {'type': 'axis', 'id': 4}
+        self.mapping['aux2'] = {'type': 'axis', 'id': 5}
+        self.mapping['aux3'] = {'type': 'axis', 'id': 6}
+        self.mapping['aux4'] = {'type': 'switch', 'id': 2}
 
-        elif 'Xbox' in self.joy.get_name() or 'X-Box' in self.joy.get_name():
-            # print "found xbox"
-            self.mapping['x'] = 3
-            self.mapping['y'] = 4
-            self.mapping['z'] = 0
-            self.mapping['F'] = 1
-            self.mapping['xsign'] = 1
-            self.mapping['ysign'] = 1
-            self.mapping['zsign'] = 1
-            self.mapping['Fsign'] = -1
-            self.mapping['aux1'] = {'type': 'button', 'id': 0}
-            self.mapping['aux2'] = {'type': 'button', 'id': 1}
-            self.mapping['aux3'] = {'type': 'button', 'id': 2}
-            self.mapping['aux4'] = {'type': 'button', 'id': 3}
-            self.look_for_button_press_events = True
+        self.keys_increase = [pygame.K_RIGHT, pygame.K_UP, pygame.K_d, pygame.K_w]
 
-        elif 'Extreme 3D' in self.joy.get_name():
-            # print "found Logitech Extreme 3D"
-            self.mapping['x'] = 0
-            self.mapping['y'] = 1
-            self.mapping['z'] = 2
-            self.mapping['F'] = 3
-            self.mapping['xsign'] = 1
-            self.mapping['ysign'] = 1
-            self.mapping['zsign'] = 1
-            self.mapping['Fsign'] = -1
-            self.mapping['aux1'] = {'type': 'button', 'id': 0}
-            self.mapping['aux2'] = {'type': 'button', 'id': 1}
-            self.mapping['aux3'] = {'type': 'button', 'id': 2}
-            self.mapping['aux4'] = {'type': 'button', 'id': 3}
-            # the Extreme 3D has actually 12 buttons, but rc_joy forwards only 4 aux keys
-            self.look_for_button_press_events = True
-
-        else:
-            print("using realflight mapping")
-            self.mapping['x'] = 1
-            self.mapping['y'] = 2
-            self.mapping['z'] = 4
-            self.mapping['F'] = 0
-            self.mapping['xsign'] = 1
-            self.mapping['ysign'] = 1
-            self.mapping['zsign'] = 1
-            self.mapping['Fsign'] = 1
-            self.mapping['aux1'] = {'type': 'axis', 'id': 3}
-            self.mapping['aux2'] = {'type': 'switch', 'id': 0}
-            self.mapping['aux3'] = {'type': 'switch', 'id': 1}
-            self.mapping['aux4'] = {'type': 'switch', 'id': 2}
+        self.keys_decrease = [pygame.K_LEFT, pygame.K_DOWN, pygame.K_a, pygame.K_s, pygame.K_o]
 
         if self.look_for_button_press_events:
             # get keys for all inputs typed as 'button'
@@ -108,7 +58,6 @@ class rosflight_keyboard_base():
             for key in self.button_keys:
                 button_value = self.joy.get_button(self.mapping[key]['id'])
                 self.prev_button_values.append(button_value)
-                self.mapping[key]['value'] = button_value
 
     def update(self):
         pygame.event.pump()
@@ -134,26 +83,38 @@ class rosflight_keyboard_base():
         # For 'switch' type aux keys, the published value is directly the current state of being pressed.
         # Updated in below loop. Same for 'axis' type aux keys.
 
+        
+                # self.keypress = True
+
         # 50 Hz update
         if time.time() > self.next_update_time:
             self.next_update_time += 0.02
 
-            self.values['x'] = self.joy.get_axis(
-                self.mapping['x']) * self.mapping['xsign']
-            self.values['y'] = self.joy.get_axis(
-                self.mapping['y']) * self.mapping['ysign']
-            self.values['F'] = self.joy.get_axis(
-                self.mapping['F']) * self.mapping['Fsign']
-            self.values['z'] = self.joy.get_axis(
-                self.mapping['z']) * self.mapping['zsign']
+
+            for event in pygame.event.get():
+                if event.type == pygame.KEYDOWN:
+                    if event.key == pygame.K_DOWN:
+                        print("Pressing down!")
+                if event.type == pygame.KEYUP:
+                    print('\nkey up: {}, {}\n'.format(event.key, pygame.key.name(event.key)))
+
+            self.values['x'] = self.mapping['xsign']
+            self.values['y'] = self.mapping['ysign']
+            self.values['F'] = self.mapping['Fsign']
+            self.values['z'] = self.mapping['zsign']
+
 
             for key in ['aux1', 'aux2', 'aux3', 'aux4']:
                 if self.mapping[key]['type'] == 'axis':
-                    self.values[key] = self.joy.get_axis(
-                        self.mapping[key]['id'])
+                    self.values[key] = 10
+                    # self.values[key] = self.joy.get_axis(
+                        # self.mapping[key]['id'])
                 elif self.mapping[key]['type'] == 'switch':
-                    self.values[key] = 2.0 * \
-                        self.joy.get_button(self.mapping[key]['id']) - 1.0
+                    self.values[key] = 1
+                    # self.values[key] = 2.0 * \
+                    #     self.joy.get_button(self.mapping[key]['id']) - 1.0
+
+            self.keypress = False
             return True
         else:
             return False

--- a/src/rosflight_joy/velocity_command_joy
+++ b/src/rosflight_joy/velocity_command_joy
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import rospy
 from rosflight_msgs.msg import Command


### PR DESCRIPTION
With pygame display window in focus, pressing WASD will mimic the left stick behavior (W/S axis stays where placed, A/D axis drifts back to zero once unpressed), and the arrow keys mimic the right stick behavior (both Up-Down and Left-Right drift back to zero once unpressed).