### PR TITLE
Improvements to rc_keyboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,41 @@ pip install pygame
 Or whatever environment you're using.
 
 There is a rosflight_joy_base class which does the auto-detection.  The other nodes create objects which inherit from this base class, but change the way the inputs are interpreted and which message is ultimately sent out.  Just change which node you are running to change modes.
+
+## rc_keyboard node
+
+Another node is provided called `rc_keyboard` which mimics the functionality of a joystick device through pressing keys on a keyboard. It is intended to be a convenience node for those using the `rosflight_joy` package in simulation. It provides some basic functionality, but only allows for very coarse control - as one would expect when flying using keyboard presses.
+
+### User instructions
+
+First, press alt+TAB until `rc_keyboard` window is focused. Once focused, pressing the following keys will result in these commands:
+
+- W/S = throttle up/down
+- A/D = yaw left/right
+- Up/Down = pitch forward/backward
+- Left/Right = roll left/right
+- M = arm toggle
+- O = RC override toggle
+- Z = set throttle to 100%
+- X = set throttle to 0%
+- C = set throttle to 50%
+
+### Automatic arm and takeoff
+
+`rc_keyboard` can optionally arm the aircraft automatically, as well as shift to full throttle after arming to allow for autonomous navigation to take over.
+
+This node assumes that the RC channels are set to: `[ROLL, PITCH, THROTTLE, YAW, RC_OVERRIDE, ARM (or none), none, none]`. i.e., it assumes that the ROSflight parameters `RC_ATT_OVRD_CHN` and `RC_THR_OVRD_CHN` are set to channel 4, and `ARM_CHANNEL` is set to channel 5 (although this last one is optional). Note that the channel number is zero-indexed.
+
+The node listens for the following ROS parameters:
+
+Format: `param_name`: (type, default value) Description of what is published to `/RC` topic, where low = -1 (min value), high = 1 (max value), and neutral = 0 (middle value)
+- `auto_arm`: (bool, false) if true,
+  - low on `F` (channel 2, throttle)
+  - high on `z` (channel 3, yaw) <-- in case `ARM_CHANNEL` is not set
+  - high on `aux1` (channel 4, RC override)
+  - high on `aux2` (channel 5, arm toggle)
+  - publish these until `/status` reports `armed: true`, after which publish low on `aux1` (RC override) and neutral to `z` (yaw)
+- `auto_takeoff`: (bool, false) if true AND `auto_arm` is true,
+  - high on `F` (channel 2, throttle) after successful arm
+
+The node waits for an incoming message on the `/version` topic before publishing anything.

--- a/src/rosflight_joy/rc_keyboard
+++ b/src/rosflight_joy/rc_keyboard
@@ -14,44 +14,48 @@ class rosflight_keyboard_RC(rosflight_keyboard_base):
         rospy.init_node('rc_keyboard')
         rospy.loginfo("[rc_keyboard] initing")
         
-        rc_pub = rospy.Publisher('RC', RCRaw, queue_size=10)
+        self.rc_pub = rospy.Publisher('RC', RCRaw, queue_size=10)
         
         self.status_sub = rospy.Subscriber('status', Status, self.status_callback)
         # waiting until firmware version is published avoids some "Unable to arm" errors
         self.version_sub = rospy.Subscriber('version', String, self.version_callback)
 
+        self.init = False
+        self.is_armed = False
+        self.got_version = False
         self.auto_arm = rospy.get_param('~auto_arm', False) 
         if self.auto_arm:
             rospy.logwarn("[rc_keyboard] auto-arming is ON. Waiting for firmware version")
         else:
             rospy.loginfo("[rc_keyboard] auto-arming is OFF.")
 
-        self.init = False
-        self.is_armed = False
-        self.got_version = False
-
+    def run(self):
         while not rospy.is_shutdown():
+            
             if self.auto_arm and not self.init:
-                if not self.got_version:
-                    continue
-                if self.is_armed:
-                    rospy.loginfo("[rc_keyboard] auto-arming successful") 
+                if self.got_version:
+                    self.arm() 
+                    if self.is_armed:
+                        self.values['aux2'] = -1
+                        self.init = True
+                        rospy.loginfo("[rc_keyboard] auto-arming successful") 
+                else:
+                    continue 
             
             self.update()
-          
+        
             msg = RCRaw()
-            msg.header.stamp = rospy.Time.now()
-            msg.values[0] = self.get_value('x') 
-            msg.values[1] = self.get_value('y') 
-            msg.values[2] = self.get_value('F') 
-            msg.values[3] = self.get_value('z') 
-            msg.values[4] = self.get_value('aux1')
-            msg.values[5] = self.get_value('aux2')
-            msg.values[6] = self.get_value('aux3')
-            msg.values[7] = self.get_value('aux4')
+            msg.header.stamp = rospy.Time.now()     # key: action  
+            msg.values[0] = self.get_value('x')     # left/right: roll 
+            msg.values[1] = self.get_value('y')     # up/down: pitch 
+            msg.values[2] = self.get_value('F')     # w/s: throttle  
+            msg.values[3] = self.get_value('z')     # a/d: yaw
+            msg.values[4] = self.get_value('aux1')  # m: arm/disarm toggle 
+            msg.values[5] = self.get_value('aux2')  # o: rc override toggle 
+            msg.values[6] = self.get_value('aux3')  
+            msg.values[7] = self.get_value('aux4')  
 
-            rc_pub.publish(msg)
-            
+            self.rc_pub.publish(msg)
             rospy.sleep(0.02)
 
         self.quit()
@@ -60,13 +64,20 @@ class rosflight_keyboard_RC(rosflight_keyboard_base):
     def get_value(self, key):
         return int(self.values[key] * 500 + 1500)
 
+    def arm(self):
+        self.values['F'] = -1
+        self.values['aux1'] = 1
+        self.values['aux2'] = 1
+        return
+        
     def status_callback(self, msg):
         self.is_armed = msg.armed
-        self.status_sub.unregister()
     
     def version_callback(self, msg):
         self.got_version = True
         self.version_sub.unregister()
 
 if __name__ == "__main__":
-    input_object = rosflight_keyboard_RC()
+    rck = rosflight_keyboard_RC()
+    rck.run()
+    

--- a/src/rosflight_joy/rc_keyboard
+++ b/src/rosflight_joy/rc_keyboard
@@ -39,7 +39,7 @@ class rosflight_keyboard_RC(rosflight_keyboard_base):
                 if self.got_version:
                     self.arm()
                     if self.is_armed:
-                        self.values['aux2'] = -1
+                        self.values['aux1'] = -1
                         self.init = True
                         rospy.loginfo("[rc_keyboard] auto-arming successful")
                 else:
@@ -54,8 +54,8 @@ class rosflight_keyboard_RC(rosflight_keyboard_base):
             msg.values[1] = self.get_value('y')    # up/down: pitch
             msg.values[2] = self.get_value('F')    # w/s: throttle
             msg.values[3] = self.get_value('z')    # a/d: yaw
-            msg.values[4] = self.get_value('aux1') # m: arm toggle (assumes ARM_CHANNEL=4)
-            msg.values[5] = self.get_value('aux2') # o: rc override toggle
+            msg.values[4] = self.get_value('aux1') # o: rc override toggle
+            msg.values[5] = self.get_value('aux2') # m: arm toggle (assumes ARM_CHANNEL=4)
             msg.values[6] = self.get_value('aux3')
             msg.values[7] = self.get_value('aux4')
 
@@ -69,8 +69,8 @@ class rosflight_keyboard_RC(rosflight_keyboard_base):
         return int(self.values[key] * 500 + 1500)
 
     def arm(self):
-        self.values['aux2'] = 1  # rc override ON
-        self.values['aux1'] = 1  # arm toggle ON
+        self.values['aux2'] = 1  # arm toggle ON
+        self.values['aux1'] = 1  # rc override ON
         self.values['F'] = -1    # throttle to 0%
 
         # In case ARM_CHANNEL is not set, this will be required to arm

--- a/src/rosflight_joy/rc_keyboard
+++ b/src/rosflight_joy/rc_keyboard
@@ -40,8 +40,8 @@ class rosflight_keyboard_RC(rosflight_keyboard_base):
     def run(self):
         while not rospy.is_shutdown():
 
-            if self.auto_arm and not self.init:
-                if self.got_version:
+            if self.got_version:
+                if self.auto_arm and not self.init:
                     self.arm()
                     if self.is_armed:
                         self.values['aux1'] = -1
@@ -51,8 +51,8 @@ class rosflight_keyboard_RC(rosflight_keyboard_base):
                         rospy.loginfo("[rc_keyboard] auto-arm was successful")
                         if not self.auto_takeoff:
                             rospy.loginfo("[rc_keyboard] increase throttle with 'w' key for manual takeoff")
-                else:
-                    continue
+            else:
+                continue
 
             if self.init:
                 self.update()

--- a/src/rosflight_joy/rc_keyboard
+++ b/src/rosflight_joy/rc_keyboard
@@ -28,7 +28,7 @@ class rosflight_keyboard_RC(rosflight_keyboard_base):
         if not self.auto_arm:
             self.auto_takeoff = False
             self.init = True
-        self.rate = rospy.Rate(50)
+        self.rate = rospy.Rate(30)
         if self.auto_arm:
             rospy.logwarn("[rc_keyboard] AUTO-ARM is ON. Waiting for firmware version")
         else:
@@ -39,7 +39,8 @@ class rosflight_keyboard_RC(rosflight_keyboard_base):
             rospy.loginfo("[rc_keyboard] AUTO-TAKEOFF is OFF.")
     def run(self):
         while not rospy.is_shutdown():
-
+            self.rate.sleep()
+          
             if self.got_version:
                 if self.auto_arm and not self.init:
                     self.arm()

--- a/src/rosflight_joy/rc_keyboard
+++ b/src/rosflight_joy/rc_keyboard
@@ -24,8 +24,8 @@ class rosflight_keyboard_RC(rosflight_keyboard_base):
         
         while not rospy.is_shutdown():
 
-            if not self.init:                                             
-                if self.auto_arm and self.is_armed:                       
+            if not self.init and self.auto_arm:
+                if self.is_armed:
                     rospy.loginfo("[rc_keyboard] auto-arming successful") 
             
             self.update()

--- a/src/rosflight_joy/rc_keyboard
+++ b/src/rosflight_joy/rc_keyboard
@@ -22,7 +22,7 @@ class rosflight_keyboard_RC(rosflight_keyboard_base):
 
         self.init = False
         self.is_armed = False
-        self.got_version = False
+        self.got_version = True
         self.auto_arm = rospy.get_param('~auto_arm', False) 
         if self.auto_arm:
             rospy.logwarn("[rc_keyboard] auto-arming is ON. Waiting for firmware version")

--- a/src/rosflight_joy/rc_keyboard
+++ b/src/rosflight_joy/rc_keyboard
@@ -27,7 +27,6 @@ class rosflight_keyboard_RC(rosflight_keyboard_base):
             if not self.init:                                             
                 if self.auto_arm and self.is_armed:                       
                     rospy.loginfo("[rc_keyboard] auto-arming successful") 
-                    self.init = True                                      
             
             self.update()
           

--- a/src/rosflight_joy/rc_keyboard
+++ b/src/rosflight_joy/rc_keyboard
@@ -4,6 +4,7 @@
 
 import rospy
 from rosflight_msgs.msg import RCRaw, Status
+from std_msgs.msg import String
 from rosflight_keyboard_base import rosflight_keyboard_base
 
 class rosflight_keyboard_RC(rosflight_keyboard_base):
@@ -11,20 +12,28 @@ class rosflight_keyboard_RC(rosflight_keyboard_base):
         rosflight_keyboard_base.__init__(self, device)
 
         rospy.init_node('rc_keyboard')
+        rospy.loginfo("[rc_keyboard] initing")
         
         rc_pub = rospy.Publisher('RC', RCRaw, queue_size=10)
         
-        rospy.Subscriber('status', Status, self.status_callback)
+        self.status_sub = rospy.Subscriber('status', Status, self.status_callback)
+        # waiting until firmware version is published avoids some "Unable to arm" errors
+        self.version_sub = rospy.Subscriber('version', String, self.version_callback)
+
         self.auto_arm = rospy.get_param('~auto_arm', False) 
-        self.is_armed = False
+        if self.auto_arm:
+            rospy.logwarn("[rc_keyboard] auto-arming is ON. Waiting for firmware version")
+        else:
+            rospy.loginfo("[rc_keyboard] auto-arming is OFF.")
+
         self.init = False
+        self.is_armed = False
+        self.got_version = False
 
-        rospy.sleep(3)
-        rospy.loginfo("[rc_keyboard] init successful")
-        
         while not rospy.is_shutdown():
-
-            if not self.init and self.auto_arm:
+            if self.auto_arm and not self.init:
+                if not self.got_version:
+                    continue
                 if self.is_armed:
                     rospy.loginfo("[rc_keyboard] auto-arming successful") 
             
@@ -53,6 +62,11 @@ class rosflight_keyboard_RC(rosflight_keyboard_base):
 
     def status_callback(self, msg):
         self.is_armed = msg.armed
+        self.status_sub.unregister()
+    
+    def version_callback(self, msg):
+        self.got_version = True
+        self.version_sub.unregister()
 
 if __name__ == "__main__":
     input_object = rosflight_keyboard_RC()

--- a/src/rosflight_joy/rc_keyboard
+++ b/src/rosflight_joy/rc_keyboard
@@ -22,7 +22,7 @@ class rosflight_keyboard_RC(rosflight_keyboard_base):
 
         self.init = False
         self.is_armed = False
-        self.got_version = True
+        self.got_version = False
         self.auto_arm = rospy.get_param('~auto_arm', False)
         if self.auto_arm:
             rospy.logwarn("[rc_keyboard] auto-arming is ON. Waiting for firmware version")

--- a/src/rosflight_joy/rc_keyboard
+++ b/src/rosflight_joy/rc_keyboard
@@ -24,14 +24,19 @@ class rosflight_keyboard_RC(rosflight_keyboard_base):
         self.is_armed = False
         self.got_version = False
         self.auto_arm = rospy.get_param('~auto_arm', False)
+        self.auto_takeoff = rospy.get_param('~auto_takeoff', False)
         if not self.auto_arm:
+            self.auto_takeoff = False
             self.init = True
         self.rate = rospy.Rate(50)
         if self.auto_arm:
-            rospy.logwarn("[rc_keyboard] auto-arming is ON. Waiting for firmware version")
+            rospy.logwarn("[rc_keyboard] AUTO-ARM is ON. Waiting for firmware version")
         else:
-            rospy.loginfo("[rc_keyboard] auto-arming is OFF.")
-
+            rospy.loginfo("[rc_keyboard] AUTO-ARM is OFF.")
+        if self.auto_takeoff:
+            rospy.logwarn("[rc_keyboard] AUTO-TAKEOFF is ON.")
+        else:
+            rospy.loginfo("[rc_keyboard] AUTO-TAKEOFF is OFF.")
     def run(self):
         while not rospy.is_shutdown():
 
@@ -40,8 +45,12 @@ class rosflight_keyboard_RC(rosflight_keyboard_base):
                     self.arm()
                     if self.is_armed:
                         self.values['aux1'] = -1
+                        if self.auto_takeoff:
+                            self.values['F'] = 1
                         self.init = True
-                        rospy.loginfo("[rc_keyboard] auto-arming successful")
+                        rospy.loginfo("[rc_keyboard] auto-arm was successful")
+                        if not self.auto_takeoff:
+                            rospy.loginfo("[rc_keyboard] increase throttle with 'w' key for manual takeoff")
                 else:
                     continue
 

--- a/src/rosflight_joy/rc_keyboard
+++ b/src/rosflight_joy/rc_keyboard
@@ -37,15 +37,17 @@ class rosflight_keyboard_RC(rosflight_keyboard_base):
             rospy.logwarn("[rc_keyboard] AUTO-TAKEOFF is ON.")
         else:
             rospy.loginfo("[rc_keyboard] AUTO-TAKEOFF is OFF.")
+
     def run(self):
         while not rospy.is_shutdown():
             self.rate.sleep()
-          
+
             if self.got_version:
                 if self.auto_arm and not self.init:
                     self.arm()
                     if self.is_armed:
                         self.values['aux1'] = -1
+                        self.values['z'] = 0
                         if self.auto_takeoff:
                             self.values['F'] = 1
                         self.init = True

--- a/src/rosflight_joy/rc_keyboard
+++ b/src/rosflight_joy/rc_keyboard
@@ -24,6 +24,9 @@ class rosflight_keyboard_RC(rosflight_keyboard_base):
         self.is_armed = False
         self.got_version = False
         self.auto_arm = rospy.get_param('~auto_arm', False)
+        if not self.auto_arm:
+            self.init = True
+        self.rate = rospy.Rate(50)
         if self.auto_arm:
             rospy.logwarn("[rc_keyboard] auto-arming is ON. Waiting for firmware version")
         else:
@@ -42,21 +45,22 @@ class rosflight_keyboard_RC(rosflight_keyboard_base):
                 else:
                     continue
 
-            self.update()
+            if self.init:
+                self.update()
 
             msg = RCRaw()
-            msg.header.stamp = rospy.Time.now()     # key: action
-            msg.values[0] = self.get_value('x')     # left/right: roll
-            msg.values[1] = self.get_value('y')     # up/down: pitch
-            msg.values[2] = self.get_value('F')     # w/s: throttle
-            msg.values[3] = self.get_value('z')     # a/d: yaw
-            msg.values[4] = self.get_value('aux1')  # m: arm/disarm toggle
-            msg.values[5] = self.get_value('aux2')  # o: rc override toggle
+            msg.header.stamp = rospy.Time.now()    # key: action
+            msg.values[0] = self.get_value('x')    # left/right: roll
+            msg.values[1] = self.get_value('y')    # up/down: pitch
+            msg.values[2] = self.get_value('F')    # w/s: throttle
+            msg.values[3] = self.get_value('z')    # a/d: yaw
+            msg.values[4] = self.get_value('aux1') # m: arm toggle (assumes ARM_CHANNEL=4)
+            msg.values[5] = self.get_value('aux2') # o: rc override toggle
             msg.values[6] = self.get_value('aux3')
             msg.values[7] = self.get_value('aux4')
 
             self.rc_pub.publish(msg)
-            rospy.sleep(0.02)
+            self.rate.sleep()
 
         self.quit()
 
@@ -65,9 +69,12 @@ class rosflight_keyboard_RC(rosflight_keyboard_base):
         return int(self.values[key] * 500 + 1500)
 
     def arm(self):
-        self.values['F'] = -1
-        self.values['aux1'] = 1
-        self.values['aux2'] = 1
+        self.values['aux2'] = 1  # rc override ON
+        self.values['aux1'] = 1  # arm toggle ON
+        self.values['F'] = -1    # throttle to 0%
+
+        # In case ARM_CHANNEL is not set, this will be required to arm
+        self.values['z'] = 1     # yaw at 100%
         return
 
     def status_callback(self, msg):

--- a/src/rosflight_joy/rc_keyboard
+++ b/src/rosflight_joy/rc_keyboard
@@ -15,7 +15,7 @@ class rosflight_keyboard_RC(rosflight_keyboard_base):
         rc_pub = rospy.Publisher('RC', RCRaw, queue_size=10)
         
         rospy.Subscriber('status', Status, self.status_callback)
-        self.auto_arm = rospy.get_param("~auto_arm", False) 
+        self.auto_arm = rospy.get_param('~auto_arm', False) 
         self.is_armed = False
         self.init = False
 

--- a/src/rosflight_joy/rc_keyboard
+++ b/src/rosflight_joy/rc_keyboard
@@ -13,9 +13,9 @@ class rosflight_keyboard_RC(rosflight_keyboard_base):
 
         rospy.init_node('rc_keyboard')
         rospy.loginfo("[rc_keyboard] initing")
-        
+
         self.rc_pub = rospy.Publisher('RC', RCRaw, queue_size=10)
-        
+
         self.status_sub = rospy.Subscriber('status', Status, self.status_callback)
         # waiting until firmware version is published avoids some "Unable to arm" errors
         self.version_sub = rospy.Subscriber('version', String, self.version_callback)
@@ -23,7 +23,7 @@ class rosflight_keyboard_RC(rosflight_keyboard_base):
         self.init = False
         self.is_armed = False
         self.got_version = True
-        self.auto_arm = rospy.get_param('~auto_arm', False) 
+        self.auto_arm = rospy.get_param('~auto_arm', False)
         if self.auto_arm:
             rospy.logwarn("[rc_keyboard] auto-arming is ON. Waiting for firmware version")
         else:
@@ -31,29 +31,29 @@ class rosflight_keyboard_RC(rosflight_keyboard_base):
 
     def run(self):
         while not rospy.is_shutdown():
-            
+
             if self.auto_arm and not self.init:
                 if self.got_version:
-                    self.arm() 
+                    self.arm()
                     if self.is_armed:
                         self.values['aux2'] = -1
                         self.init = True
-                        rospy.loginfo("[rc_keyboard] auto-arming successful") 
+                        rospy.loginfo("[rc_keyboard] auto-arming successful")
                 else:
-                    continue 
-            
+                    continue
+
             self.update()
-        
+
             msg = RCRaw()
-            msg.header.stamp = rospy.Time.now()     # key: action  
-            msg.values[0] = self.get_value('x')     # left/right: roll 
-            msg.values[1] = self.get_value('y')     # up/down: pitch 
-            msg.values[2] = self.get_value('F')     # w/s: throttle  
+            msg.header.stamp = rospy.Time.now()     # key: action
+            msg.values[0] = self.get_value('x')     # left/right: roll
+            msg.values[1] = self.get_value('y')     # up/down: pitch
+            msg.values[2] = self.get_value('F')     # w/s: throttle
             msg.values[3] = self.get_value('z')     # a/d: yaw
-            msg.values[4] = self.get_value('aux1')  # m: arm/disarm toggle 
-            msg.values[5] = self.get_value('aux2')  # o: rc override toggle 
-            msg.values[6] = self.get_value('aux3')  
-            msg.values[7] = self.get_value('aux4')  
+            msg.values[4] = self.get_value('aux1')  # m: arm/disarm toggle
+            msg.values[5] = self.get_value('aux2')  # o: rc override toggle
+            msg.values[6] = self.get_value('aux3')
+            msg.values[7] = self.get_value('aux4')
 
             self.rc_pub.publish(msg)
             rospy.sleep(0.02)
@@ -69,15 +69,17 @@ class rosflight_keyboard_RC(rosflight_keyboard_base):
         self.values['aux1'] = 1
         self.values['aux2'] = 1
         return
-        
+
     def status_callback(self, msg):
         self.is_armed = msg.armed
-    
+
     def version_callback(self, msg):
         self.got_version = True
         self.version_sub.unregister()
 
 if __name__ == "__main__":
     rck = rosflight_keyboard_RC()
-    rck.run()
-    
+    try:
+        rck.run()
+    except rospy.ROSInterruptException as e:
+        pass

--- a/src/rosflight_joy/rosflight_keyboard_base.py
+++ b/src/rosflight_joy/rosflight_keyboard_base.py
@@ -59,7 +59,7 @@ class rosflight_keyboard_base():
 
     def update(self):
 
-        if self.auto_arm and not self.init:
+        if not self.init and self.auto_arm:
             self.values['F'] = -1
             self.values['z'] =  1
             if self.is_armed:

--- a/src/rosflight_joy/rosflight_keyboard_base.py
+++ b/src/rosflight_joy/rosflight_keyboard_base.py
@@ -58,17 +58,10 @@ class rosflight_keyboard_base():
         self.switch_interval_time = 0.25
 
     def update(self):
-
-        if not self.init and self.auto_arm:
-            self.values['F'] = -1
-            self.values['z'] =  1
-            if self.is_armed:
-                self.values['F'] = 0
-                self.values['z'] =  0
-                self.values['aux1'] = -1
-                self.init = True
+        if self.auto_arm and not self.init:
+            self.arm()
             return
-        
+
         pygame.event.pump()
 
         # 50 Hz update
@@ -130,6 +123,17 @@ class rosflight_keyboard_base():
                 val += self.delta if val < 0 else -self.delta
             self.values[n] = val
     
+    def arm(self):
+        self.values['F'] = -1
+        self.values['z'] =  1
+        if self.is_armed:
+            self.values['F'] = 0
+            self.values['z'] =  0
+            self.values['aux1'] = -1
+            self.init = True
+        return
+        
+        
     def quit(self):
         pygame.quit()
         sys.exit(0)

--- a/src/rosflight_joy/rosflight_keyboard_base.py
+++ b/src/rosflight_joy/rosflight_keyboard_base.py
@@ -33,7 +33,7 @@ class rosflight_keyboard_base():
         self.values['y'] = 0
         self.values['F'] = 0
         self.values['z'] = 0
-        self.values['aux1'] =  1
+        self.values['aux1'] = 1
         self.values['aux2'] = -1
         self.values['aux3'] = -1
         self.values['aux4'] = -1
@@ -62,7 +62,12 @@ class rosflight_keyboard_base():
         if self.auto_arm and not self.init:
             self.values['F'] = -1
             self.values['z'] =  1
-            return False
+            if self.is_armed:
+                self.values['F'] = 0
+                self.values['z'] =  0
+                self.values['aux1'] = -1
+                self.init = True
+            return
         
         pygame.event.pump()
 

--- a/src/rosflight_joy/rosflight_keyboard_base.py
+++ b/src/rosflight_joy/rosflight_keyboard_base.py
@@ -29,8 +29,8 @@ class rosflight_keyboard_base():
         self.values['y'] = 0      # up/down: pitch
         self.values['F'] = -1     # w/s: throttle
         self.values['z'] = 0      # a/d: yaw
-        self.values['aux1'] = -1  # m: arm toggle (assumes ARM_CHANNEL=4)
-        self.values['aux2'] = -1  # o: rc override toggle
+        self.values['aux1'] = -1  # o: rc override toggle
+        self.values['aux2'] = -1  # m: arm toggle (assumes ARM_CHANNEL=4)
         self.values['aux3'] = -1
         self.values['aux4'] = -1
 
@@ -44,8 +44,8 @@ class rosflight_keyboard_base():
             (pygame.K_s,     'F', -1),
             (pygame.K_a,     'z', -1),
             (pygame.K_d,     'z',  1),
-            (pygame.K_m,  'aux1',  1),
-            (pygame.K_o,  'aux2',  1)
+            (pygame.K_o,  'aux1',  1),
+            (pygame.K_m,  'aux2',  1)
         ], dtypes)
 
         self.delta = 0.05  # amount per interval that axis values slide towards zero

--- a/src/rosflight_joy/rosflight_keyboard_base.py
+++ b/src/rosflight_joy/rosflight_keyboard_base.py
@@ -36,19 +36,19 @@ class rosflight_keyboard_base():
 
         dtypes = [('id', int), ('name', object), ('sign', int)]
         self.actions = np.array([
-            (pygame.K_UP,    'y', -1),
-            (pygame.K_DOWN,  'y',  1),
-            (pygame.K_LEFT,  'x', -1),
-            (pygame.K_RIGHT, 'x',  1),
-            (pygame.K_w,     'F',  1),
-            (pygame.K_s,     'F', -1),
-            (pygame.K_a,     'z', -1),
-            (pygame.K_d,     'z',  1),
-            (pygame.K_o,  'aux1',  1),
-            (pygame.K_m,  'aux2',  1),
-            (pygame.K_c, 'Fhalf',  1),
-            (pygame.K_x, 'Fzero',  1),
-            (pygame.K_z, 'Ffull',  1)
+            (pygame.KSCAN_UP,    'y', -1),
+            (pygame.KSCAN_DOWN,  'y',  1),
+            (pygame.KSCAN_LEFT,  'x', -1),
+            (pygame.KSCAN_RIGHT, 'x',  1),
+            (pygame.KSCAN_W,     'F',  1),
+            (pygame.KSCAN_S,     'F', -1),
+            (pygame.KSCAN_A,     'z', -1),
+            (pygame.KSCAN_D,     'z',  1),
+            (pygame.KSCAN_O,  'aux1',  1),
+            (pygame.KSCAN_M,  'aux2',  1),
+            (pygame.KSCAN_C, 'Fhalf',  1),
+            (pygame.KSCAN_X, 'Fzero',  1),
+            (pygame.KSCAN_Z, 'Ffull',  1)
         ], dtypes)
 
         self.delta = 0.1  # amount per interval that axis values slide towards zero

--- a/src/rosflight_joy/rosflight_keyboard_base.py
+++ b/src/rosflight_joy/rosflight_keyboard_base.py
@@ -23,17 +23,17 @@ class rosflight_keyboard_base():
 
         self.print_limits = False
         self.limit_reached = False
-        
+
         self.values = dict()       # key: action
         self.values['x'] = 0       # left/right: roll
         self.values['y'] = 0       # up/down: pitch
-        self.values['F'] = -1      # w/s: throttle 
+        self.values['F'] = -1      # w/s: throttle
         self.values['z'] = 0       # a/d: yaw
-        self.values['aux1'] = -1   # m: arm/disarm toggle 
-        self.values['aux2'] = -1   # o: rc override toggle 
+        self.values['aux1'] = -1   # m: arm/disarm toggle
+        self.values['aux2'] = -1   # o: rc override toggle
         self.values['aux3'] = -1
         self.values['aux4'] = -1
-        
+
         dtypes = [('id', int), ('name', object), ('sign', int)]
         self.actions = np.array([
             (pygame.K_UP,    'y', -1),
@@ -74,29 +74,26 @@ class rosflight_keyboard_base():
                         if name == 'aux1':
                             if t > self.wait_until_time['aux1']:
                                 self.values['aux1'] *= -1
-                                # print('aux1 is pressed!!!!!!!!!!! new value:', self.values['aux1'])
                                 self.wait_until_time['aux1'] = t + self.switch_interval_time
-                        elif name == 'aux2': 
+                        elif name == 'aux2':
                             if t > self.wait_until_time['aux2']:
                                 self.values['aux2'] *= -1
-                                # print('aux2 is pressed!!!!!!!!!!! new value:', self.values['aux2'])
                                 self.wait_until_time['aux2'] = t + self.switch_interval_time
                         elif key == pygame.K_q:
                             self.quit()
                         else:
                             self.shift_value(name, sign)
-                            
+
             self.slide_to_zero(keys)
 
     def shift_value(self, name, sign):
         ''' increment or decrement value of axis [name] in [sign] direction'''
         self.values[name] += sign * self.delta
         val = self.values[name]
-        # print('shifting \"{}\" to new value: {}'.format(name, val))
         if abs(val) >= 1.0:
             val = 1.0 if val > 0 else -1.0
             if not self.limit_reached and self.print_limits:
-                print('{} {} value reached'.format(name, 
+                print('{} {} value reached'.format(name,
                                             'max' if val > 0 else 'min'))
                 self.limit_reached = True
         else:
@@ -105,11 +102,9 @@ class rosflight_keyboard_base():
         if abs(val) < 1e-6:
             val = 0.
         self.values[name] = val
-        
-        # print('\tcorrected \"{}\" value: {}'.format(name, val))
-        
+
     def slide_to_zero(self, keys):
-        ''' for x, y, z axes push values closer to zero if not currently pressed 
+        ''' for x, y, z axes push values closer to zero if not currently pressed
             (mimics joystick behavior)
         '''
         for n in ['x', 'y', 'z']:
@@ -119,15 +114,15 @@ class rosflight_keyboard_base():
                     is_pressed = True
             if is_pressed:
                 continue
-                
+
             val = self.values[n]
             if abs(val) < 1e-6 and val != 0.:
                 val = 0.
             elif val != 0.:
                 val += self.delta if val < 0 else -self.delta
             self.values[n] = val
-    
-        
+
+
     def quit(self):
         pygame.quit()
         sys.exit(0)

--- a/src/rosflight_joy/rosflight_keyboard_base.py
+++ b/src/rosflight_joy/rosflight_keyboard_base.py
@@ -24,13 +24,13 @@ class rosflight_keyboard_base():
         self.print_limits = False
         self.limit_reached = False
 
-        self.values = dict()       # key: action
-        self.values['x'] = 0       # left/right: roll
-        self.values['y'] = 0       # up/down: pitch
-        self.values['F'] = -1      # w/s: throttle
-        self.values['z'] = 0       # a/d: yaw
-        self.values['aux1'] = -1   # m: arm/disarm toggle
-        self.values['aux2'] = -1   # o: rc override toggle
+        self.values = dict()      # key: action
+        self.values['x'] = 0      # left/right: roll
+        self.values['y'] = 0      # up/down: pitch
+        self.values['F'] = -1     # w/s: throttle
+        self.values['z'] = 0      # a/d: yaw
+        self.values['aux1'] = -1  # m: arm toggle (assumes ARM_CHANNEL=4)
+        self.values['aux2'] = -1  # o: rc override toggle
         self.values['aux3'] = -1
         self.values['aux4'] = -1
 


### PR DESCRIPTION
- More helpful info logging
- Waits for firmware version to be published before attempting to auto-arm
- When `ARM_CHANNEL` is set to `5`, allows for use of 'm' key to toggle arm/disarm
- auto-arming now works for above case and for case when `ARM_CHANNEL` is disabled/not set
- Adds auto_takeoff rosparam that when set to true will publish its last RC message with throttle set to 100%
- Better code organization, improved explanatory comments